### PR TITLE
docker: pin des images de base + xdebug désactivé en prod

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM jflahaut/nginx-php:latest
+FROM jflahaut/nginx-php:v1.1.0
 
 # Copier les sources
 WORKDIR /var/www/html

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine as builder
+FROM node:20.19-alpine3.21 as builder
 
 WORKDIR /app
 COPY app/ .
@@ -10,7 +10,7 @@ ENV NUXT_PUBLIC_SANCTUM_BASE_URL=$NUXT_PUBLIC_SANCTUM_BASE_URL
 RUN npm install && npm run build
 
 # Étape pour servir l'app (Nitro standalone ou node server)
-FROM node:20-alpine
+FROM node:20.19-alpine3.21
 
 WORKDIR /app
 COPY --from=builder /app/.output ./.output

--- a/scraper/Dockerfile
+++ b/scraper/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:slim
+FROM python:3.12-slim-bookworm
 
 WORKDIR /app
 


### PR DESCRIPTION
Pin des versions des images Docker et allègement de l'image de base.

- backend: `jflahaut/nginx-php:latest` → `:v1.1.0` (image 1.13 Go → 720 Mo, debian pinné, xdebug off par défaut)
- frontend: `node:20-alpine` → `node:20.19-alpine3.21`
- scraper: `python:slim` → `python:3.12-slim-bookworm`

xdebug est désormais désactivé par défaut dans l'image de base (rien en prod) ; activable en dev via `XDEBUG_MODE` dans le `docker-compose.override.yml` (local, gitignoré).

⚠️ Nécessite `jflahaut/nginx-php:v1.1.0` — déjà publié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)